### PR TITLE
improve stack trace logs with %+v

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -128,7 +128,10 @@ func (x *Error) Format(s fmt.State, verb rune) {
 	case 'v':
 		if s.Flag('+') {
 			_, _ = io.WriteString(s, x.Error())
-			x.st.Format(s, verb)
+			var c *Error
+			for c = x; c.cause != nil; c = c.cause.(*Error) {
+			}
+			c.st.Format(s, verb)
 			return
 		}
 		fallthrough

--- a/examples/stacktrace_print/main.go
+++ b/examples/stacktrace_print/main.go
@@ -2,20 +2,27 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/m-mizutani/goerr"
 )
 
-func someAction(fname string) error {
-	if _, err := os.Open(fname); err != nil {
-		return goerr.Wrap(err, "failed to open file")
+func nestedAction2() error {
+	return goerr.New("fatal error in the nested action2")
+}
+
+func nestedAction() error {
+	return goerr.Wrap(nestedAction2(), "nestedAction2 failed")
+}
+
+func someAction() error {
+	if err := nestedAction(); err != nil {
+		return goerr.Wrap(err, "nestedAction failed")
 	}
 	return nil
 }
 
 func main() {
-	if err := someAction("no_such_file.txt"); err != nil {
+	if err := someAction(); err != nil {
 		log.Fatalf("%+v", err)
 	}
 }


### PR DESCRIPTION
# example

examples/stacktrace_print/main.go

## before
```
2024/05/12 16:45:48 nestedAction failed: nestedAction2 failed: fatal error in the nested action2
main.someAction
        /path/to/goerr/examples/stacktrace_print/main.go:19
main.main
        /path/to/goerr/examples/stacktrace_print/main.go:25
runtime.main
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/runtime/proc.go:271
runtime.goexit
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/runtime/asm_arm64.s:1222
exit status 1
```

## after
```
2024/05/12 16:45:03 nestedAction failed: nestedAction2 failed: fatal error in the nested action2
main.nestedAction2
        /path/to/goerr/examples/stacktrace_print/main.go:10
main.nestedAction
        /path/to/goerr/examples/stacktrace_print/main.go:14
main.someAction
        /path/to/goerr/examples/stacktrace_print/main.go:18
main.main
        /path/to/goerr/examples/stacktrace_print/main.go:25
runtime.main
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/runtime/proc.go:271
runtime.goexit
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/runtime/asm_arm64.s:1222
exit status 1
```