### PR TITLE
Add context feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,32 @@ Output:
 }
 ```
 
+### Context
 
+`goerr` provides `WithContext` method to add values from context to the error. Values can be added to context.Context by `goerr.InjectValue`.
+
+```go
+func someAction(id requestID) error {
+	ctx := context.Background()
+	ctx = goerr.InjectValue(ctx, "request_id", id)
+
+	// ... some action
+
+	return goerr.New("failed").WithContext(ctx)
+}
+
+func main() {
+	id := requestID("req-123")
+	if err := someAction(id); err != nil {
+		slog.Default().Error("aborted", slog.Any("error", err))
+	}
+}
+```
+
+Output:
+```
+2024/10/19 09:51:04 ERROR aborted error.message=failed error.values.request_id=req-123 (snip)
+```
 
 ## License
 

--- a/context.go
+++ b/context.go
@@ -1,0 +1,24 @@
+package goerr
+
+import "context"
+
+type errContext struct {
+	values map[string]any
+}
+
+type errContextKey struct{}
+
+func InjectValue(ctx context.Context, key string, value any) context.Context {
+	newCtx := errContext{
+		values: make(map[string]any),
+	}
+	oldCtx, ok := ctx.Value(errContextKey{}).(*errContext)
+	if ok {
+		for k, v := range oldCtx.values {
+			newCtx.values[k] = v
+		}
+	}
+
+	newCtx.values[key] = value
+	return context.WithValue(ctx, errContextKey{}, &newCtx)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,41 @@
+package goerr_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-mizutani/goerr"
+)
+
+func funcWithContext(ctx context.Context, color string) error {
+	if color != "red" {
+		return goerr.New("color is not red").With("color", color).WithContext(ctx)
+	}
+	return nil
+}
+
+func TestContext(t *testing.T) {
+	reqID := "req-123"
+
+	ctx := context.Background()
+	ctx = goerr.InjectValue(ctx, "request_id", reqID)
+
+	err := funcWithContext(ctx, "blue")
+
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+
+	goErr := goerr.Unwrap(err)
+	if goErr == nil {
+		t.Error("Expected goerr.Error, got other type")
+	}
+
+	if goErr.Values()["color"] != "blue" {
+		t.Errorf("Expected color value to be 'blue', got '%v'", goErr.Values()["color"])
+	}
+
+	if goErr.Values()["request_id"] != reqID {
+		t.Errorf("Expected request_id value to be '%s', got '%v'", reqID, goErr.Values()["request_id"])
+	}
+}

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/m-mizutani/goerr"
+)
+
+type requestID string
+
+func someAction(id requestID) error {
+	ctx := context.Background()
+	ctx = goerr.InjectValue(ctx, "request_id", id)
+
+	// ... some action
+
+	return goerr.New("failed").WithContext(ctx)
+}
+
+func main() {
+	id := requestID("req-123")
+	if err := someAction(id); err != nil {
+		slog.Default().Error("aborted", slog.Any("error", err))
+	}
+}


### PR DESCRIPTION
This PR adds `WithContext` method to add values from context to the error. Values can be added to context.Context by `goerr.InjectValue`.

```go
func someAction(id requestID) error {
	ctx := context.Background()
	ctx = goerr.InjectValue(ctx, "request_id", id)

	// ... some action

	return goerr.New("failed").WithContext(ctx)
}

func main() {
	id := requestID("req-123")
	if err := someAction(id); err != nil {
		slog.Default().Error("aborted", slog.Any("error", err))
	}
}
```

Output:
```
2024/10/19 09:51:04 ERROR aborted error.message=failed error.values.request_id=req-123 (snip)
```