### PR TITLE
feat(tag): Tag feature experimentally

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -73,6 +73,7 @@ type Error struct {
 	st     *stack
 	cause  error
 	values values
+	tags   tagStorage
 }
 
 func newError() *Error {
@@ -80,6 +81,7 @@ func newError() *Error {
 		st:     callers(),
 		values: make(values),
 		id:     uuid.New().String(),
+		tags:   newTagStorage(),
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -73,7 +73,7 @@ type Error struct {
 	st     *stack
 	cause  error
 	values values
-	tags   tagStorage
+	tags   tags
 }
 
 func newError() *Error {
@@ -81,7 +81,7 @@ func newError() *Error {
 		st:     callers(),
 		values: make(values),
 		id:     uuid.New().String(),
-		tags:   newTagStorage(),
+		tags:   make(tags),
 	}
 }
 
@@ -89,9 +89,8 @@ func (x *Error) copy(dst *Error) {
 	dst.msg = x.msg
 	dst.id = x.id
 	dst.cause = x.cause
-	for k, v := range x.values {
-		dst.values[k] = v
-	}
+	dst.tags = x.tags.clone()
+	dst.values = x.values.clone()
 	// st (stacktrace) is not copied
 }
 
@@ -107,6 +106,9 @@ func (x *Error) Printable() *printable {
 	for k, v := range x.values {
 		e.Values[k] = v
 	}
+	for tag := range x.tags {
+		e.Tags = append(e.Tags, tag.value)
+	}
 	return e
 }
 
@@ -116,6 +118,7 @@ type printable struct {
 	StackTrace []*Stack       `json:"stacktrace"`
 	Cause      error          `json:"cause"`
 	Values     map[string]any `json:"values"`
+	Tags       []string       `json:"tags"`
 }
 
 // Error returns error message for error interface

--- a/examples/tag/main.go
+++ b/examples/tag/main.go
@@ -44,5 +44,6 @@ func main() {
 		_, _ = w.Write([]byte("OK"))
 	})
 
+	// #nosec
 	http.ListenAndServe(":8090", nil)
 }

--- a/examples/tag/main.go
+++ b/examples/tag/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/m-mizutani/goerr"
+)
+
+var (
+	ErrTagSysError   = goerr.NewTag("system_error")
+	ErrTagBadRequest = goerr.NewTag("bad_request")
+)
+
+func handleError(w http.ResponseWriter, err error) {
+	if goErr := goerr.Unwrap(err); goErr != nil {
+		switch {
+		case goErr.HasTag(ErrTagSysError):
+			w.WriteHeader(http.StatusInternalServerError)
+		case goErr.HasTag(ErrTagBadRequest):
+			w.WriteHeader(http.StatusBadRequest)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	_, _ = w.Write([]byte(err.Error()))
+}
+
+func someAction() error {
+	if _, err := http.Get("http://example.com/some/resource"); err != nil {
+		return goerr.Wrap(err, "failed to get some resource").WithTags(ErrTagSysError)
+	}
+	return nil
+}
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if err := someAction(); err != nil {
+			handleError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	http.ListenAndServe(":8090", nil)
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,1 @@
+package goerr

--- a/tag.go
+++ b/tag.go
@@ -1,0 +1,110 @@
+package goerr
+
+import (
+	"fmt"
+	"io"
+)
+
+// TagKey is a type to represent a key of the tag. The struct should be created by only NewTagKey function.
+type TagKey struct {
+	key string
+}
+
+func NewTagKey(key string) TagKey {
+	return TagKey{key: key}
+}
+
+// Tag is a type to represent an error tag. It is used to categorize errors. The struct should be created by only NewTag function.
+//
+// Example:
+//
+//	TagNotFound := NewTag("not_found")
+//
+//	func FindUser(id string) (*User, error) {
+//		...
+//		if user == nil {
+//			return nil, goerr.New("user not found").WithTags(TagNotFound)
+//		}
+//		...
+//	}
+//
+//	func main() {
+//		err := FindUser("123")
+//		if goErr := goerr.Unwrap(err); goErr != nil {
+//			if goErr.HasTag(TagNotFound) {
+//				fmt.Println("User not found")
+//			}
+//		}
+//	}
+type Tag struct {
+	key   TagKey
+	value string
+}
+
+// NewTag creates a new Tag. The key will be empty.
+func NewTag(value string) Tag {
+	return Tag{value: value}
+}
+
+// NewTagWithKey creates a new Tag with the key. The key is used to identify the tag.
+func NewTagWithKey(key TagKey, value string) Tag {
+	return Tag{key: key, value: value}
+}
+
+// String returns the string representation of the Tag. It's for implementing fmt.Stringer interface.
+func (t Tag) String() string {
+	return t.value
+}
+
+// Format writes the Tag to the writer. It's for implementing fmt.Formatter interface.
+func (t Tag) Format(s fmt.State, verb rune) {
+	io.WriteString(s, t.value)
+}
+
+// WithTags adds tags to the error. The tags are used to categorize errors.
+func (x *Error) WithTags(tags ...Tag) *Error {
+	for _, tag := range tags {
+		x.tags.add(tag)
+	}
+	return x
+}
+
+// HasTag returns true if the error has the tag.
+func (x *Error) HasTag(tag Tag) bool {
+	return x.tags.has(tag)
+}
+
+// LookupTag returns the tag with the key. If the tag is not found, it returns false.
+func (x *Error) LookupTag(key TagKey) (Tag, bool) {
+	tag, ok := x.tags.tagsWithKey[key]
+	return tag, ok
+}
+
+type tagStorage struct {
+	tagsWithoutKey map[Tag]struct{}
+	tagsWithKey    map[TagKey]Tag
+}
+
+func newTagStorage() tagStorage {
+	return tagStorage{
+		tagsWithoutKey: make(map[Tag]struct{}),
+		tagsWithKey:    make(map[TagKey]Tag),
+	}
+}
+
+func (t tagStorage) add(tag Tag) {
+	if tag.key.key == "" {
+		t.tagsWithoutKey[tag] = struct{}{}
+		return
+	}
+	t.tagsWithKey[tag.key] = tag
+}
+
+func (t tagStorage) has(tag Tag) bool {
+	if tag.key.key == "" {
+		_, ok := t.tagsWithoutKey[tag]
+		return ok
+	}
+	_, ok := t.tagsWithKey[tag.key]
+	return ok
+}

--- a/tag.go
+++ b/tag.go
@@ -58,7 +58,7 @@ func (t Tag) String() string {
 
 // Format writes the Tag to the writer. It's for implementing fmt.Formatter interface.
 func (t Tag) Format(s fmt.State, verb rune) {
-	io.WriteString(s, t.value)
+	_, _ = io.WriteString(s, t.value)
 }
 
 // WithTags adds tags to the error. The tags are used to categorize errors.

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,38 @@
+package goerr_test
+
+import (
+	"fmt"
+
+	"github.com/m-mizutani/goerr"
+)
+
+func ExampleNewTag() {
+	t1 := goerr.NewTag("DB error")
+	err := goerr.New("error message").WithTags(t1)
+
+	if goErr := goerr.Unwrap(err); goErr != nil {
+		if goErr.HasTag(t1) {
+			fmt.Println("DB error")
+		}
+	}
+	// Output: DB error
+}
+
+func ExampleNewTagWithKey() {
+	k1 := goerr.NewTagKey("http")
+	tagNotFound := goerr.NewTagWithKey(k1, "404")
+	tagUnauthorized := goerr.NewTagWithKey(k1, "401")
+	err := goerr.New("resource not found").WithTags(tagNotFound)
+
+	if goErr := goerr.Unwrap(err); goErr != nil {
+		switch tag, ok := goErr.LookupTag(k1); {
+		case ok && tag == tagNotFound:
+			fmt.Println("not found")
+		case ok && tag == tagUnauthorized:
+			fmt.Println("unauthorized")
+		default:
+			fmt.Println("unknown")
+		}
+	}
+	// Output: not found
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -2,6 +2,7 @@ package goerr_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/m-mizutani/goerr"
 )
@@ -18,21 +19,41 @@ func ExampleNewTag() {
 	// Output: DB error
 }
 
-func ExampleNewTagWithKey() {
-	k1 := goerr.NewTagKey("http")
-	tagNotFound := goerr.NewTagWithKey(k1, "404")
-	tagUnauthorized := goerr.NewTagWithKey(k1, "401")
-	err := goerr.New("resource not found").WithTags(tagNotFound)
+func TestNewTag(t *testing.T) {
+	tagValue := "test_tag"
+	tag := goerr.NewTag(tagValue)
+
+	if tag.String() != tagValue {
+		t.Errorf("expected tag value to be %s, got %s", tagValue, tag.String())
+	}
+}
+
+func TestWithTags(t *testing.T) {
+	tag1 := goerr.NewTag("tag1")
+	tag2 := goerr.NewTag("tag2")
+	tag3 := goerr.NewTag("tag3")
+	err := goerr.New("error message").WithTags(tag1, tag2)
 
 	if goErr := goerr.Unwrap(err); goErr != nil {
-		switch tag, ok := goErr.LookupTag(k1); {
-		case ok && tag == tagNotFound:
-			fmt.Println("not found")
-		case ok && tag == tagUnauthorized:
-			fmt.Println("unauthorized")
-		default:
-			fmt.Println("unknown")
+		if !goErr.HasTag(tag1) {
+			t.Errorf("expected error to have tag1")
+		}
+		if !goErr.HasTag(tag2) {
+			t.Errorf("expected error to have tag2")
+		}
+		if goErr.HasTag(tag3) {
+			t.Errorf("expected error to not have tag3")
 		}
 	}
-	// Output: not found
+}
+
+func TestHasTag(t *testing.T) {
+	tag := goerr.NewTag("test_tag")
+	err := goerr.New("error message").WithTags(tag)
+
+	if goErr := goerr.Unwrap(err); goErr != nil {
+		if !goErr.HasTag(tag) {
+			t.Errorf("expected error to have tag")
+		}
+	}
 }


### PR DESCRIPTION
# Motivation

There are use cases where we need to adjust the error handling strategy based on the nature of the error. A clear example is an HTTP server, where the status code to be returned varies depending on whether it's an error from a downstream system, a missing resource, or an unauthorized request. To handle this precisely, you could predefine errors for each type and use methods like `errors.Is` in the error handling section to verify and branch the processing accordingly. However, this approach becomes challenging as the program grows larger and the number and variety of errors increase.

`goerr` provides a `With` method that allows parameters to be set on errors. However, specifying parameters as strings each time raises concerns about typos, leaving room for errors during development.

This pull request (PR) introduces a mechanism to prevent typos by predefining `Tag`s and only accepting that type, thus enhancing reliability in development.

# Example

```go
var (
	ErrTagSysError   = goerr.NewTag("system_error")
	ErrTagBadRequest = goerr.NewTag("bad_request")
)

func handleError(w http.ResponseWriter, err error) {
	if goErr := goerr.Unwrap(err); goErr != nil {
		switch {
		case goErr.HasTag(ErrTagSysError):
			w.WriteHeader(http.StatusInternalServerError)
		case goErr.HasTag(ErrTagBadRequest):
			w.WriteHeader(http.StatusBadRequest)
		default:
			w.WriteHeader(http.StatusInternalServerError)
		}
	} else {
		w.WriteHeader(http.StatusInternalServerError)
	}
	_, _ = w.Write([]byte(err.Error()))
}

func someAction() error {
	if _, err := http.Get("http://example.com/some/resource"); err != nil {
		return goerr.Wrap(err, "failed to get some resource").WithTags(ErrTagSysError)
	}
	return nil
}

func main() {
	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		if err := someAction(); err != nil {
			handleError(w, err)
			return
		}
		w.WriteHeader(http.StatusOK)
		_, _ = w.Write([]byte("OK"))
	})

	http.ListenAndServe(":8090", nil)
}
```