### PR TITLE
reach: Functional options pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Package `goerr` provides more contextual error handling in Go.
 - Stack traces
   - Compatible with `github.com/pkg/errors`.
   - Structured stack traces with `goerr.Stack` is available.
-- Contextual variables to errors using `With(key, value)`.
+- Contextual variables to errors using:
+  - Key value data by `goerr.Value(key, value)` (or `goerr.V(key, value)` as alias).
+  - Tag value data can be defined by `goerr.NewTag` and set into error by `goerr.Tag(tag)` (or `goerr.T(tag)` as alias).
 - `errors.Is` to identify errors and `errors.As` to unwrap errors.
 - `slog.LogValuer` interface to output structured logs with `slog`.
 
@@ -86,8 +88,7 @@ if err := someAction("no_such_file.txt"); err != nil {
 
 ### Add/Extract contextual variables
 
-
-`goerr` provides the `With(key, value)` method to add contextual variables to errors. The standard way to handle errors in Go is by injecting values into error messages. However, this approach makes it difficult to aggregate various errors. On the other hand, `goerr`'s `With` method allows for adding contextual information to errors without changing error message, making it easier to aggregate error logs. Additionally, error handling services like Sentry.io can handle errors more accurately with this feature.
+`goerr` provides the `Value(key, value)` method to add contextual variables to errors. The standard way to handle errors in Go is by injecting values into error messages. However, this approach makes it difficult to aggregate various errors. On the other hand, `goerr`'s `Value` method allows for adding contextual information to errors without changing error message, making it easier to aggregate error logs. Additionally, error handling services like Sentry.io can handle errors more accurately with this feature.
 
 ```go
 var errFormatMismatch = errors.New("format mismatch")
@@ -95,7 +96,7 @@ var errFormatMismatch = errors.New("format mismatch")
 func someAction(tasks []task) error {
 	for _, t := range tasks {
 		if err := validateData(t.Data); err != nil {
-			return goerr.Wrap(err, "failed to validate data").With("name", t.Name)
+			return goerr.Wrap(err, "failed to validate data", goerr.Value("name", t.Name))
 		}
 	}
 	// ....
@@ -104,7 +105,7 @@ func someAction(tasks []task) error {
 
 func validateData(data string) error {
 	if !strings.HasPrefix(data, "data:") {
-		return goerr.Wrap(errFormatMismatch).With("data", data)
+		return goerr.Wrap(errFormatMismatch, goerr.Value("data", data))
 	}
 	return nil
 }
@@ -170,7 +171,7 @@ func someAction(input string) error {
 
 func validate(input string) error {
 	if input != "OK" {
-		return goerr.Wrap(errRuntime, "invalid input").With("input", input)
+		return goerr.Wrap(errRuntime, "invalid input", goerr.V("input", input))
 	}
 	return nil
 }
@@ -226,7 +227,7 @@ type object struct {
 }
 
 func (o *object) Validate() error {
-	eb := goerr.NewBuilder().With("id", o.id)
+	eb := goerr.NewBuilder(goerr.Value("id", o.id))
 
 	if o.color == "" {
 		return eb.New("color is empty")

--- a/builder.go
+++ b/builder.go
@@ -1,40 +1,39 @@
 package goerr
 
-import (
-	"fmt"
-)
-
 // Builder keeps a set of key-value pairs and can create a new error and wrap error with the key-value pairs.
 type Builder struct {
-	values values
+	options []Option
 }
 
 // NewBuilder creates a new Builder
-func NewBuilder() *Builder {
-	return &Builder{values: make(values)}
+func NewBuilder(options ...Option) *Builder {
+	return &Builder{
+		options: options,
+	}
 }
 
 // With copies the current Builder and adds a new key-value pair.
+//
+// Deprecated: Use goerr.Value instead.
 func (x *Builder) With(key string, value any) *Builder {
-	newVS := &Builder{values: x.values.clone()}
-	newVS.values[key] = value
-	return newVS
+	newBuilder := &Builder{
+		options: x.options[:],
+	}
+	newBuilder.options = append(newBuilder.options, Value(key, value))
+	return newBuilder
 }
 
 // New creates a new error with message
-func (x *Builder) New(format string, args ...any) *Error {
-	err := newError()
-	err.msg = fmt.Sprintf(format, args...)
-	err.values = x.values.clone()
-
+func (x *Builder) New(msg string, options ...Option) *Error {
+	err := newError(append(x.options, options...)...)
+	err.msg = msg
 	return err
 }
 
 // Wrap creates a new Error with caused error and add message.
-func (x *Builder) Wrap(cause error, msg ...any) *Error {
-	err := newError()
-	err.msg = toWrapMessage(msg)
+func (x *Builder) Wrap(cause error, msg string, options ...Option) *Error {
+	err := newError(append(x.options, options...)...)
+	err.msg = msg
 	err.cause = cause
-	err.values = x.values.clone()
 	return err
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newErrorWithBuilder() *goerr.Error {
-	return goerr.NewBuilder().With("color", "orange").New("error")
+	return goerr.NewBuilder(goerr.V("color", "orange")).New("error")
 }
 
 func TestBuilderNew(t *testing.T) {
@@ -20,7 +20,7 @@ func TestBuilderNew(t *testing.T) {
 
 func TestBuilderWrap(t *testing.T) {
 	cause := goerr.New("cause")
-	err := goerr.NewBuilder().With("color", "blue").Wrap(cause, "error")
+	err := goerr.NewBuilder(goerr.V("color", "blue")).Wrap(cause, "error")
 
 	if err.Values()["color"] != "blue" {
 		t.Errorf("Unexpected value: %v", err.Values())

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -10,7 +10,10 @@ import (
 
 func someAction(input string) error {
 	if input != "OK" {
-		return goerr.New("input is not OK").With("input", input).With("time", time.Now())
+		return goerr.New("input is not OK",
+			goerr.Value("input", input),
+			goerr.Value("time", time.Now()),
+		)
 	}
 	return nil
 }

--- a/examples/errors_is/main.go
+++ b/examples/errors_is/main.go
@@ -11,7 +11,7 @@ var errInvalidInput = errors.New("invalid input")
 
 func someAction(input string) error {
 	if input != "OK" {
-		return goerr.Wrap(errInvalidInput, "input is not OK").With("input", input)
+		return goerr.Wrap(errInvalidInput, "input is not OK", goerr.Value("input", input))
 	}
 	// .....
 	return nil

--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -20,7 +20,7 @@ func someAction(input string) error {
 
 func validate(input string) error {
 	if input != "OK" {
-		return goerr.Wrap(errRuntime, "invalid input").With("input", input)
+		return goerr.Wrap(errRuntime, "invalid input", goerr.V("input", input))
 	}
 	return nil
 }

--- a/examples/tag/main.go
+++ b/examples/tag/main.go
@@ -29,7 +29,7 @@ func handleError(w http.ResponseWriter, err error) {
 
 func someAction() error {
 	if _, err := http.Get("http://example.com/some/resource"); err != nil {
-		return goerr.Wrap(err, "failed to get some resource").WithTags(ErrTagSysError)
+		return goerr.Wrap(err, "failed to get some resource", goerr.T(ErrTagSysError))
 	}
 	return nil
 }

--- a/examples/variables/main.go
+++ b/examples/variables/main.go
@@ -13,7 +13,7 @@ var errFormatMismatch = errors.New("format mismatch")
 func someAction(tasks []task) error {
 	for _, t := range tasks {
 		if err := validateData(t.Data); err != nil {
-			return goerr.Wrap(err, "failed to validate data").With("name", t.Name)
+			return goerr.Wrap(err, "failed to validate data", goerr.Value("name", t.Name))
 		}
 	}
 	// ....
@@ -22,7 +22,7 @@ func someAction(tasks []task) error {
 
 func validateData(data string) error {
 	if !strings.HasPrefix(data, "data:") {
-		return goerr.Wrap(errFormatMismatch).With("data", data)
+		return goerr.Wrap(errFormatMismatch, "validation error", goerr.V("data", data))
 	}
 	return nil
 }

--- a/tag.go
+++ b/tag.go
@@ -14,7 +14,7 @@ import (
 //	func FindUser(id string) (*User, error) {
 //		...
 //		if user == nil {
-//			return nil, goerr.New("user not found").WithTags(TagNotFound)
+//			return nil, goerr.New("user not found", goerr.Tag(TagNotFound))
 //		}
 //		...
 //	}
@@ -27,27 +27,29 @@ import (
 //			}
 //		}
 //	}
-type Tag struct {
+type tag struct {
 	value string
 }
 
 // NewTag creates a new Tag. The key will be empty.
-func NewTag(value string) Tag {
-	return Tag{value: value}
+func NewTag(value string) tag {
+	return tag{value: value}
 }
 
 // String returns the string representation of the Tag. It's for implementing fmt.Stringer interface.
-func (t Tag) String() string {
+func (t tag) String() string {
 	return t.value
 }
 
 // Format writes the Tag to the writer. It's for implementing fmt.Formatter interface.
-func (t Tag) Format(s fmt.State, verb rune) {
+func (t tag) Format(s fmt.State, verb rune) {
 	_, _ = io.WriteString(s, t.value)
 }
 
 // WithTags adds tags to the error. The tags are used to categorize errors.
-func (x *Error) WithTags(tags ...Tag) *Error {
+//
+// Deprecated: Use goerr.Tag instead.
+func (x *Error) WithTags(tags ...tag) *Error {
 	for _, tag := range tags {
 		x.tags.add(tag)
 	}
@@ -55,17 +57,17 @@ func (x *Error) WithTags(tags ...Tag) *Error {
 }
 
 // HasTag returns true if the error has the tag.
-func (x *Error) HasTag(tag Tag) bool {
+func (x *Error) HasTag(tag tag) bool {
 	return x.tags.has(tag)
 }
 
-type tags map[Tag]struct{}
+type tags map[tag]struct{}
 
-func (t tags) add(tag Tag) {
+func (t tags) add(tag tag) {
 	t[tag] = struct{}{}
 }
 
-func (t tags) has(tag Tag) bool {
+func (t tags) has(tag tag) bool {
 	_, ok := t[tag]
 	return ok
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -9,7 +9,7 @@ import (
 
 func ExampleNewTag() {
 	t1 := goerr.NewTag("DB error")
-	err := goerr.New("error message").WithTags(t1)
+	err := goerr.New("error message", goerr.Tag(t1))
 
 	if goErr := goerr.Unwrap(err); goErr != nil {
 		if goErr.HasTag(t1) {
@@ -32,7 +32,7 @@ func TestWithTags(t *testing.T) {
 	tag1 := goerr.NewTag("tag1")
 	tag2 := goerr.NewTag("tag2")
 	tag3 := goerr.NewTag("tag3")
-	err := goerr.New("error message").WithTags(tag1, tag2)
+	err := goerr.New("error message", goerr.Tag(tag1), goerr.Tag(tag2))
 
 	if goErr := goerr.Unwrap(err); goErr != nil {
 		if !goErr.HasTag(tag1) {
@@ -49,7 +49,7 @@ func TestWithTags(t *testing.T) {
 
 func TestHasTag(t *testing.T) {
 	tag := goerr.NewTag("test_tag")
-	err := goerr.New("error message").WithTags(tag)
+	err := goerr.New("error message", goerr.Tag(tag))
 
 	if goErr := goerr.Unwrap(err); goErr != nil {
 		if !goErr.HasTag(tag) {


### PR DESCRIPTION
> [!CAUTION]
> This PR has breaking changes


# Motivation

The `goerr` package previously utilized the `With` method to attach contextual information to errors. However, over time, several issues have been identified with this approach:

- It is unclear whether the method performs a destructive change on the original object.
- Actually, it does perform destructive changes, resulting in an error object that is not immutable.
- The implementation of a tagging feature led to the creation of a separate method, `WithTags`, which lacks consistency with the `With` method. This inconsistency may lead to similar issues when adding new features in the future.

To address these concerns, the goal of this pull request (PR) is to implement the functionality for attaching parameters to errors using the functional options pattern. This approach will make it more explicit that the generated error objects are immutable.




