### PR TITLE
enhance(format): Show values in `+v` format

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -199,6 +199,14 @@ func (x *Error) Format(s fmt.State, verb rune) {
 				c = cause
 			}
 			c.st.Format(s, verb)
+			_, _ = io.WriteString(s, "\n")
+
+			if len(x.values) > 0 {
+				_, _ = io.WriteString(s, "\nValues:\n")
+				for k, v := range x.values {
+					_, _ = io.WriteString(s, fmt.Sprintf("  %s: %v\n", k, v))
+				}
+			}
 			return
 		}
 		fallthrough

--- a/errors.go
+++ b/errors.go
@@ -206,6 +206,7 @@ func (x *Error) Format(s fmt.State, verb rune) {
 				for k, v := range x.values {
 					_, _ = io.WriteString(s, fmt.Sprintf("  %s: %v\n", k, v))
 				}
+				_, _ = io.WriteString(s, "\n")
 			}
 			return
 		}

--- a/errors_test.go
+++ b/errors_test.go
@@ -355,7 +355,10 @@ func TestFormat(t *testing.T) {
 
 	b := &bytes.Buffer{}
 	fmt.Fprintf(b, "%+v", err)
-	if !strings.Contains(b.String(), "- color=blue") {
-		t.Errorf("Expected log output to contain 'color=blue', got '%s'", b.String())
+	if !strings.Contains(b.String(), "color: blue") {
+		t.Errorf("Expected log output to contain 'color: blue', got '%s'", b.String())
+	}
+	if !strings.Contains(b.String(), "number: 123") {
+		t.Errorf("Expected log output to contain 'number: 123', got '%s'", b.String())
 	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -349,3 +349,13 @@ func TestValues(t *testing.T) {
 		t.Errorf("Expected value for 'number' to be 'five', got '%v'", values["number"])
 	}
 }
+
+func TestFormat(t *testing.T) {
+	err := goerr.New("omg", goerr.V("color", "blue"), goerr.V("number", 123))
+
+	b := &bytes.Buffer{}
+	fmt.Fprintf(b, "%+v", err)
+	if !strings.Contains(b.String(), "- color=blue") {
+		t.Errorf("Expected log output to contain 'color=blue', got '%s'", b.String())
+	}
+}


### PR DESCRIPTION
The values can be shown with stacktrace

Example:

```
omg
github.com/m-mizutani/goerr/v2_test.TestFormat
        /Users/mizutani/.ghq/github.com/m-mizutani/goerr/errors_test.go:354
testing.tRunner
        /usr/local/go/src/testing/testing.go:1792
runtime.goexit
        /usr/local/go/src/runtime/asm_arm64.s:1223

Values:
  color: blue
  number: 123
```